### PR TITLE
feat: add --rename-with option to rename command in Go and Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ go run . --help
 Python:
 
 ```bash
+poetry run organizer rename --working-dir ./downloads --target-dir ./renamed --rename-with invoice
 poetry run organizer separate --mode extension --extension pdf --working-dir ./in --target-dir ./out --history
 poetry run organizer merge --mode file --working-dir ./downloads --working-dir ./desktop --target-dir ./merged
 poetry run organizer revert --directory ./out
@@ -45,6 +46,7 @@ poetry run organizer revert --directory ./out
 Go:
 
 ```bash
+go run . rename --working-dir ./downloads --target-dir ./renamed --rename-with invoice
 go run . separate --mode extension --extension pdf --working-dir ./in --target-dir ./out --history
 go run . merge --mode file --working-dir ./downloads --working-dir ./desktop --target-dir ./merged
 go run . revert --directory ./out

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,19 +1,122 @@
-# Roadmap
+# Organizer CLI – Future Feature Roadmap
 
-## Near Term
+## File Discovery
+- Recursive directory traversal
+- Include pattern filtering (`--include`)
+- Ignore pattern filtering (`--ignore`)
+- File size filtering (`--min-size`, `--max-size`)
+- Time filters (`--before`, `--after`, `--older-than`)
+- Hidden file handling
+- Depth limiting (`--max-depth`)
 
-- Keep Python and Go command behavior fully aligned.
-- Expand test coverage for edge cases in `merge` and `revert` flows.
-- Improve error messages and exit codes for invalid CLI arguments.
+## Conflict Handling
+- `--conflict rename` (current default)
+- `--conflict overwrite`
+- `--conflict skip`
+- `--conflict fail`
+- `--conflict prompt`
 
-## Mid Term
+## File Type Detection
+- MIME-type detection
+- Smart file categorization
+- Extension normalization
+- File signature detection
 
-- Add shell completion generation and docs for both CLIs.
-- Add benchmark-style checks for large directory operations.
-- Add release asset checksums/signing for better artifact trust.
+## Sorting Enhancements
+- Sort by file size
+- Sort by creation time
+- Sort by modification time
+- Sort by filename patterns
+- Sort by multiple conditions
+- Custom folder naming templates
 
-## Future
+## Automation
+- Watch mode (`organizer watch`)
+- Scheduled execution support
+- Continuous folder monitoring
+- Rule-based automation
 
-- Evaluate config-file driven organization presets.
-- Add optional dry-run diff preview across all modes.
-- Improve cross-platform path normalization and consistency reporting.
+## Config System
+- YAML config file support
+- JSON config support
+- Config validation
+- Multiple config profiles
+- Config override via CLI flags
+
+## Rule Engine
+- Multi-rule execution
+- Conditional rules
+- Rule priority system
+- Rule chaining
+- Rule preview
+
+## Safety Features
+- Operation confirmation prompt
+- Protected directory detection
+- Safe mode
+- Max file operation limits
+- Undo stack improvements
+- Operation history viewer
+
+## Output & UX
+- Colored terminal output
+- Progress bars
+- Verbose mode
+- Debug mode
+- JSON output mode
+- Quiet mode
+- Operation summary improvements
+
+## Performance
+- Parallel file processing
+- Batch file operations
+- Optimized directory scanning
+- Memory usage optimization
+- Large directory handling
+
+## Duplicate Handling
+- Duplicate file detection
+- Hash-based duplicate detection
+- Duplicate removal
+- Duplicate grouping
+- Duplicate reporting
+
+## CLI Improvements
+- Shell autocompletion (bash/zsh/fish)
+- Interactive mode
+- Command aliases
+- Better help formatting
+- Command suggestions
+
+## Logging
+- File logging
+- Structured logs
+- Log levels
+- Operation logs
+
+## Integration
+- Homebrew installation
+- Scoop installation
+- AUR package
+- Docker image
+- OS context menu integration
+
+## Developer Features
+- Plugin system
+- Hook system
+- Custom rule extensions
+- External script execution
+- API mode
+
+## Reporting
+- File operation reports
+- Directory statistics
+- File distribution reports
+- Export reports (JSON/CSV)
+
+## Long-term Features
+- Remote directory support
+- Cloud storage support
+- GUI companion tool
+- Web dashboard
+- AI-assisted file categorization

--- a/file-organiser-go/README.md
+++ b/file-organiser-go/README.md
@@ -33,7 +33,8 @@ Working directory flags are validated before any `--target-dir` creation prompt.
 
 ## `rename`
 
-Renames files in `working_dir` to numeric names (`1.ext`, `2.ext`, ...) and moves them to `target_dir`.
+Renames files in `working_dir` and moves them to `target_dir`.
+By default names are numeric (`1.ext`, `2.ext`, ...); with `--rename-with` they become prefixed (`name_1.ext`, `name_2.ext`, ...).
 
 ### Options
 
@@ -41,6 +42,7 @@ Renames files in `working_dir` to numeric names (`1.ext`, `2.ext`, ...) and move
 - `--target-dir PATH` (default: current directory)
 - `--dry-run`
 - `--history` (save history file for revert)
+- `--rename-with TEXT` (optional base name prefix, e.g. `invoice`)
 
 If `--target-dir` is provided and does not exist, the CLI prompts to create it (`y/n`).
 Declining exits with a `--target-dir` error.
@@ -49,6 +51,7 @@ Declining exits with a `--target-dir` error.
 
 ```bash
 go run . rename --working-dir ./downloads --target-dir ./renamed --history
+go run . rename --working-dir ./downloads --target-dir ./renamed --rename-with invoice
 ```
 
 ## `separate`

--- a/file-organiser-go/cmd/rename.go
+++ b/file-organiser-go/cmd/rename.go
@@ -11,6 +11,7 @@ func newRenameCmd() *cobra.Command {
 	var workingDir string
 	var dryRun bool
 	var saveHistory bool
+	var renameWith string
 
 	cmd := &cobra.Command{
 		Use:   "rename",
@@ -30,6 +31,7 @@ func newRenameCmd() *cobra.Command {
 				WorkingDir:  workingDir,
 				DryRun:      dryRun,
 				SaveHistory: saveHistory,
+				RenameWith:  renameWith,
 			}
 
 			fo, err := organizer.NewFileOrganizer(cfg)
@@ -45,6 +47,6 @@ func newRenameCmd() *cobra.Command {
 	cmd.Flags().StringVar(&workingDir, "working-dir", "", "Source directory to process")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview actions without making changes")
 	cmd.Flags().BoolVar(&saveHistory, "history", false, "Save operation history")
-
+	cmd.Flags().StringVar(&renameWith, "rename-with", "", "Rename files with a prefix or suffix")
 	return cmd
 }

--- a/file-organiser-go/internal/organizer/organizer.go
+++ b/file-organiser-go/internal/organizer/organizer.go
@@ -21,6 +21,7 @@ type Config struct {
 	WorkingDirs []string
 	DryRun      bool
 	SaveHistory bool
+	RenameWith  string
 }
 
 type FileOrganizer struct {
@@ -34,6 +35,7 @@ type FileOrganizer struct {
 	dryRun      bool
 	saveHistory bool
 	historyPath string
+	renameWith  string
 }
 
 func NewFileOrganizer(cfg Config) (*FileOrganizer, error) {
@@ -90,6 +92,7 @@ func NewFileOrganizer(cfg Config) (*FileOrganizer, error) {
 		workingDirs: resolvedWorkingDirs,
 		dryRun:      cfg.DryRun,
 		saveHistory: cfg.SaveHistory,
+		renameWith:  cfg.RenameWith,
 	}
 
 	if fo.saveHistory {
@@ -128,6 +131,9 @@ func (f *FileOrganizer) Rename(out io.Writer) error {
 	for index, filePath := range files {
 		ext := filepath.Ext(filePath)
 		newName := fmt.Sprintf("%d%s", index+1, ext)
+		if f.renameWith != "" {
+			newName = fmt.Sprintf("%s_%d%s", f.renameWith, index+1, ext)
+		}
 		destinationPath := filepath.Join(f.targetDir, newName)
 		newPath := buildNonConflictingPath(destinationPath)
 

--- a/file-organiser-go/internal/organizer/organizer_test.go
+++ b/file-organiser-go/internal/organizer/organizer_test.go
@@ -101,6 +101,33 @@ func TestRenameCollisionAndRevertRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRenameWithPrefixHandlesCollision(t *testing.T) {
+	base := t.TempDir()
+	work := filepath.Join(base, "work")
+	out := filepath.Join(base, "out")
+
+	mustWriteFile(t, filepath.Join(work, "a.txt"), "a")
+	mustWriteFile(t, filepath.Join(work, "b.txt"), "b")
+	mustWriteFile(t, filepath.Join(out, "invoice_1.txt"), "existing")
+
+	fo, err := NewFileOrganizer(Config{TargetDir: out, WorkingDir: work, RenameWith: "invoice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var outBuf bytes.Buffer
+	if err := fo.Rename(&outBuf); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(out, "invoice_1_1.txt")); err != nil {
+		t.Fatalf("expected collision-safe prefixed file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "invoice_2.txt")); err != nil {
+		t.Fatalf("expected second prefixed file: %v", err)
+	}
+}
+
 func TestHistoryFilenameIsUniquePerRun(t *testing.T) {
 	base := t.TempDir()
 	out := filepath.Join(base, "out")

--- a/file-organiser-python/README.md
+++ b/file-organiser-python/README.md
@@ -34,7 +34,8 @@ Working directory flags are validated before any `--target-dir` creation prompt.
 
 ## `rename`
 
-Renames files in `working_dir` to numeric names (`1.ext`, `2.ext`, ...) and moves them to `target_dir`.
+Renames files in `working_dir` and moves them to `target_dir`.
+By default names are numeric (`1.ext`, `2.ext`, ...); with `--rename-with` they become prefixed (`name_1.ext`, `name_2.ext`, ...).
 
 ### Options
 
@@ -42,6 +43,7 @@ Renames files in `working_dir` to numeric names (`1.ext`, `2.ext`, ...) and move
 - `--target-dir PATH` (default: current directory)
 - `--dry-run`
 - `--history` (save history file for revert)
+- `--rename-with TEXT` (optional base name prefix, e.g. `invoice`)
 
 If `--target-dir` is provided and does not exist, the CLI prompts to create it (`y/n`).
 Declining exits with a `--target-dir` error.
@@ -50,6 +52,7 @@ Declining exits with a `--target-dir` error.
 
 ```bash
 organizer rename --working-dir ./downloads --target-dir ./renamed --history
+organizer rename --working-dir ./downloads --target-dir ./renamed --rename-with invoice
 ```
 
 ## `separate`

--- a/file-organiser-python/src/file_organiser_python/main.py
+++ b/file-organiser-python/src/file_organiser_python/main.py
@@ -102,6 +102,11 @@ def rename(
     ),
     dry_run: bool = typer.Option(False, help="Preview actions without making changes."),
     history: bool = typer.Option(False, "--history", help="Save operation history."),
+    renameWith: Optional[str] = typer.Option(
+        None,
+        "--rename-with",
+        help="Base name to use for renamed files (e.g. 'file' to get 'file_1.pdf', 'file_2.pdf', etc.).",
+    ),
 ) -> None:
     _validate_optional_directory(working_dir, "--working-dir")
     target_dir = _resolve_target_directory(target_dir, dry_run=dry_run)
@@ -112,6 +117,7 @@ def rename(
             working_dir=working_dir,
             dry_run=dry_run,
             save_history=history,
+            renameWith=renameWith,
         )
     except (MissingTargetDirectoryError, TargetPathNotDirectoryError) as exc:
         raise typer.BadParameter(str(exc), param_hint="--target-dir") from exc

--- a/file-organiser-python/src/file_organiser_python/organizer.py
+++ b/file-organiser-python/src/file_organiser_python/organizer.py
@@ -41,6 +41,7 @@ class FileOrganizer:
         save_history: bool = False,
         sort_date: Optional[str] = None,
         sort_extension: Optional[str] = None,
+        renameWith: Optional[str] = None,
         file_type: Optional[str] = None,
         separate_choice: Optional[SeparateChoices] = SeparateChoices.EXTENSION,
     ) -> None:
@@ -62,6 +63,7 @@ class FileOrganizer:
         self.save_history = save_history
         self.sort_date = sort_date
         self.sort_extension = sort_extension
+        self.renameWith = renameWith
         self.file_type = file_type
         self.separate_choice = separate_choice
         self.history_path: Optional[Path] = None
@@ -83,8 +85,13 @@ class FileOrganizer:
         rename_map: dict[str, str] = {}
 
         for index, file in enumerate(sorted(files), start=1):
-            new_name = f"{index}{file.suffix}"
+            if self.renameWith:
+                new_name = f"{self.renameWith}_{index}{file.suffix}"
+            else:
+                new_name = f"{index}{file.suffix}"
+
             destination_path = self.target_dir / new_name
+
             new_path = build_non_conflicting_path(destination_path)
 
             original_path = file.resolve()

--- a/file-organiser-python/tests/test_organizer.py
+++ b/file-organiser-python/tests/test_organizer.py
@@ -87,6 +87,21 @@ class TestOrganizerFixes(unittest.TestCase):
         self.assertFalse((self.out / "1_1.txt").exists())
         self.assertFalse(history_path.exists())
 
+    def test_renameWith_prefix_handles_collision(self) -> None:
+        (self.work / "a.txt").write_text("a", encoding="utf-8")
+        (self.work / "b.txt").write_text("b", encoding="utf-8")
+        (self.out / "invoice_1.txt").write_text("existing", encoding="utf-8")
+
+        organizer = FileOrganizer(
+            target_dir=self.out,
+            working_dir=self.work,
+            renameWith="invoice",
+        )
+        organizer.rename()
+
+        self.assertTrue((self.out / "invoice_1_1.txt").exists())
+        self.assertTrue((self.out / "invoice_2.txt").exists())
+
     def test_history_filename_is_unique_per_run(self) -> None:
         organizer1 = FileOrganizer(target_dir=self.out, save_history=True)
         organizer2 = FileOrganizer(target_dir=self.out, save_history=True)


### PR DESCRIPTION
This pull request introduces a new `--rename-with` option to both the Go and Python Organizer CLI tools, allowing users to specify a prefix for file renaming operations (e.g., `invoice_1.txt`, `invoice_2.txt`). The changes ensure that the new option is documented, implemented in both codebases, and thoroughly tested for collision handling. Additionally, the roadmap documentation has been significantly expanded to outline future features and directions for the project.

**New Feature: Rename Prefix Support**

- Added a `--rename-with` option to the `rename` command in both Go and Python CLIs, enabling users to specify a prefix for renamed files (e.g., `--rename-with invoice` produces `invoice_1.txt`, `invoice_2.txt`, etc.). [[1]](diffhunk://#diff-aa3faa6c1f0876544b167a0d15af37174ee15537fcdf926f3beafddf3847ad59R14) [[2]](diffhunk://#diff-aa3faa6c1f0876544b167a0d15af37174ee15537fcdf926f3beafddf3847ad59L48-R50) [[3]](diffhunk://#diff-18a07a1613ce855db5ee701d2c9dbb63320c56c66d72b587010a0256cb1c6d83R105-R109) [[4]](diffhunk://#diff-18a07a1613ce855db5ee701d2c9dbb63320c56c66d72b587010a0256cb1c6d83R120) [[5]](diffhunk://#diff-a33254a4b66b8115b15487bad5b80113db552fc3d9a94547ff6953ee65daf119R44) [[6]](diffhunk://#diff-a33254a4b66b8115b15487bad5b80113db552fc3d9a94547ff6953ee65daf119R66)
- Updated the file renaming logic in both implementations to use the prefix if provided, and ensured collision-safe file naming [[1]](diffhunk://#diff-b26672ec3f781bdabed819b68d07672c2588a79cbbd4697153d77dfffbdfa5edR134-R136) [[2]](diffhunk://#diff-a33254a4b66b8115b15487bad5b80113db552fc3d9a94547ff6953ee65daf119R88-R94).

**Documentation Updates**

- Updated CLI documentation in both Go and Python `README.md` files to describe the new `--rename-with` option, including usage examples. [[1]](diffhunk://#diff-c92e77d0c406607cb1d3abf03d713cec7325499fafb760db87a0c87510e6fa2cL36-R45) [[2]](diffhunk://#diff-c92e77d0c406607cb1d3abf03d713cec7325499fafb760db87a0c87510e6fa2cR54) [[3]](diffhunk://#diff-35714d948ee0cf72884f7825faa927b8e43f90f1d64716803cda32dffc505c0dL37-R46) [[4]](diffhunk://#diff-35714d948ee0cf72884f7825faa927b8e43f90f1d64716803cda32dffc505c0dR55) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49)
- Significantly expanded the `ROADMAP.md` to provide a detailed outline of planned features and improvements for Organizer CLI, including automation, config system, rule engine, safety features, output enhancements, performance, duplicate handling, CLI improvements, logging, integration, developer features, reporting, and long-term goals.

**Testing Enhancements**

- Added new tests in both Go and Python to verify that the `--rename-with` option handles filename collisions correctly, ensuring unique output filenames when conflicts occur. [[1]](diffhunk://#diff-10a206b2004d4d17d19ea1597ca17af025b3fc563f2213c8688da6fde8ad4815R104-R130) [[2]](diffhunk://#diff-6f33548f71f2d63effbdc7af8427c034200913460122dc6ca4b4a61a18897815R90-R104)

**Internal Codebase Changes**

- Updated configuration and internal state handling in both codebases to support the new `renameWith` parameter. [[1]](diffhunk://#diff-b26672ec3f781bdabed819b68d07672c2588a79cbbd4697153d77dfffbdfa5edR24) [[2]](diffhunk://#diff-b26672ec3f781bdabed819b68d07672c2588a79cbbd4697153d77dfffbdfa5edR38) [[3]](diffhunk://#diff-b26672ec3f781bdabed819b68d07672c2588a79cbbd4697153d77dfffbdfa5edR95)

These changes improve the flexibility of file renaming and lay the groundwork for future enhancements to the Organizer CLI tools.