### PR TITLE
feat(cli): add terminal spinner UX for file operations

### DIFF
--- a/filecraft-go/README.md
+++ b/filecraft-go/README.md
@@ -38,6 +38,7 @@ go build -o Filecraft .
 
 All commands support `--dry-run` to preview actions without moving files.
 Working directory flags are validated before any `--target-dir` creation prompt.
+When running in an interactive terminal, Filecraft shows a spinner for long-running operations (`rename`, `separate`, `merge`, `revert`).
 
 ## `rename`
 

--- a/filecraft-go/cmd/merge.go
+++ b/filecraft-go/cmd/merge.go
@@ -49,7 +49,9 @@ func newMergeCmd() *cobra.Command {
 				return err
 			}
 
-			return fo.Merge(cmd.OutOrStdout())
+			return runWithSpinner("Merging files", cmd.ErrOrStderr(), func() error {
+				return fo.Merge(cmd.OutOrStdout())
+			})
 		},
 	}
 

--- a/filecraft-go/cmd/rename.go
+++ b/filecraft-go/cmd/rename.go
@@ -41,7 +41,9 @@ func newRenameCmd() *cobra.Command {
 				return err
 			}
 
-			return fo.Rename(cmd.OutOrStdout())
+			return runWithSpinner("Renaming files", cmd.ErrOrStderr(), func() error {
+				return fo.Rename(cmd.OutOrStdout())
+			})
 		},
 	}
 

--- a/filecraft-go/cmd/revert.go
+++ b/filecraft-go/cmd/revert.go
@@ -22,14 +22,18 @@ func newRevertCmd() *cobra.Command {
 				return err
 			}
 
-			reverted, err := organizer.RevertHistory(
-				historyFile,
-				directory,
-				dryRun,
-				!keepHistory,
-				cmd.OutOrStdout(),
-			)
-			if err != nil {
+			var reverted int
+			if err := runWithSpinner("Reverting files", cmd.ErrOrStderr(), func() error {
+				count, err := organizer.RevertHistory(
+					historyFile,
+					directory,
+					dryRun,
+					!keepHistory,
+					cmd.OutOrStdout(),
+				)
+				reverted = count
+				return err
+			}); err != nil {
 				return err
 			}
 

--- a/filecraft-go/cmd/separate.go
+++ b/filecraft-go/cmd/separate.go
@@ -51,7 +51,9 @@ func newSeparateCmd() *cobra.Command {
 				return err
 			}
 
-			return fo.Separate(cmd.OutOrStdout())
+			return runWithSpinner("Separating files", cmd.ErrOrStderr(), func() error {
+				return fo.Separate(cmd.OutOrStdout())
+			})
 		},
 	}
 

--- a/filecraft-go/cmd/spinner.go
+++ b/filecraft-go/cmd/spinner.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+func runWithSpinner(message string, errOut io.Writer, action func() error) error {
+	if !isTerminalWriter(errOut) {
+		return action()
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		frames := []rune{'|', '/', '-', '\\'}
+		i := 0
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				fmt.Fprintf(errOut, "\r%s... %c", message, frames[i%len(frames)])
+				i++
+			}
+		}
+	}()
+
+	success := false
+	defer func() {
+		close(stop)
+		<-done
+		status := "failed"
+		if success {
+			status = "done"
+		}
+		fmt.Fprintf(errOut, "\r%s... %s\n", message, status)
+	}()
+
+	if err := action(); err != nil {
+		return err
+	}
+
+	success = true
+	return nil
+}
+
+func isTerminalWriter(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+
+	return (info.Mode() & os.ModeCharDevice) != 0
+}

--- a/filecraft-python/README.md
+++ b/filecraft-python/README.md
@@ -66,6 +66,7 @@ PYTHONPATH=src python -m file_organiser_python.main --help
 
 All commands support `--dry-run` to preview actions without moving files.
 Working directory flags are validated before any `--target-dir` creation prompt.
+When running in an interactive terminal, Filecraft shows a spinner for long-running operations (`rename`, `separate`, `merge`, `revert`).
 
 ## `rename`
 

--- a/filecraft-python/src/file_organiser_python/main.py
+++ b/filecraft-python/src/file_organiser_python/main.py
@@ -11,6 +11,7 @@ from file_organiser_python.organizer import (
     MissingTargetDirectoryError,
     TargetPathNotDirectoryError,
 )
+from file_organiser_python.spinner import cli_spinner
 from file_organiser_python.utils import validate_directory
 
 app = typer.Typer()
@@ -127,7 +128,8 @@ def rename(
         )
     except (MissingTargetDirectoryError, TargetPathNotDirectoryError) as exc:
         raise typer.BadParameter(str(exc), param_hint="--target-dir") from exc
-    organizer.rename()
+    with cli_spinner("Renaming files"):
+        organizer.rename()
 
 
 @app.command()
@@ -186,7 +188,8 @@ def separate(
         )
     except (MissingTargetDirectoryError, TargetPathNotDirectoryError) as exc:
         raise typer.BadParameter(str(exc), param_hint="--target-dir") from exc
-    organizer.separate()
+    with cli_spinner("Separating files"):
+        organizer.separate()
 
 
 @app.command()
@@ -211,12 +214,13 @@ def revert(
 ) -> None:
     _validate_optional_directory(directory, "--directory")
 
-    reverted = revert_history(
-        history_path=history_file,
-        directory=directory,
-        dry_run=dry_run,
-        delete_after_revert=not keep_history,
-    )
+    with cli_spinner("Reverting files"):
+        reverted = revert_history(
+            history_path=history_file,
+            directory=directory,
+            dry_run=dry_run,
+            delete_after_revert=not keep_history,
+        )
     print(f"Reverted {reverted} file(s).")
 
 
@@ -270,7 +274,8 @@ def merge(
         )
     except (MissingTargetDirectoryError, TargetPathNotDirectoryError) as exc:
         raise typer.BadParameter(str(exc), param_hint="--target-dir") from exc
-    organizer.merge()
+    with cli_spinner("Merging files"):
+        organizer.merge()
 
 
 if __name__ == "__main__":

--- a/filecraft-python/src/file_organiser_python/spinner.py
+++ b/filecraft-python/src/file_organiser_python/spinner.py
@@ -1,0 +1,53 @@
+import itertools
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from typing import Generator, Optional, TextIO
+
+
+def _is_tty(stream: TextIO) -> bool:
+    try:
+        return stream.isatty()
+    except Exception:
+        return False
+
+
+@contextmanager
+def cli_spinner(
+    message: str,
+    *,
+    stream: Optional[TextIO] = None,
+    interval: float = 0.1,
+) -> Generator[None, None, None]:
+    target_stream = stream or sys.stderr
+
+    if not _is_tty(target_stream):
+        yield
+        return
+
+    stop_event = threading.Event()
+
+    def _spin() -> None:
+        for frame in itertools.cycle("|/-\\"):
+            if stop_event.is_set():
+                break
+            target_stream.write(f"\r{message}... {frame}")
+            target_stream.flush()
+            time.sleep(interval)
+
+    spinner_thread = threading.Thread(target=_spin, daemon=True)
+    spinner_thread.start()
+
+    success = True
+    try:
+        yield
+    except Exception:
+        success = False
+        raise
+    finally:
+        stop_event.set()
+        spinner_thread.join(timeout=max(interval * 2, 0.2))
+        status = "done" if success else "failed"
+        target_stream.write(f"\r{message}... {status}\n")
+        target_stream.flush()


### PR DESCRIPTION
## Summary
- add a terminal-aware spinner for long-running CLI operations in both implementations
- wrap rename, separate, merge, and revert command execution with spinner feedback
- keep behavior unchanged for non-interactive output (CI/tests/piped output)
- document spinner behavior in both implementation READMEs

## Parity
- Python and Go now both show the same operation-level spinner UX with matching status semantics (done/failed) in interactive terminals
- spinner output is intentionally disabled for non-TTY streams in both implementations

## Validation
- Go tests (targeted): passed via VS Code test runner (30 tests)
- Python tests: python -m unittest discover -s tests -p 'test_*.py' (82 passed)
- Pre-commit hooks ran successfully on commit (black, gofmt, go vet)

## Notes
- No new runtime dependencies were added in either implementation
- Changes are command-layer only; organizer business logic remains unchanged
